### PR TITLE
Add `wasserstein` and `squared2wasserstein`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimalTransport"
 uuid = "7e02d93a-ae51-4f58-b602-d97af76e3b33"
 authors = ["zsteve <stephenz@student.unimelb.edu.au>"]
-version = "0.3.5"
+version = "0.3.6"
 
 [deps]
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimalTransport"
 uuid = "7e02d93a-ae51-4f58-b602-d97af76e3b33"
 authors = ["zsteve <stephenz@student.unimelb.edu.au>"]
-version = "0.3.6"
+version = "0.3.7"
 
 [deps]
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -11,15 +11,21 @@ uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
 [[BenchmarkTools]]
 deps = ["JSON", "Logging", "Printf", "Statistics", "UUIDs"]
-git-tree-sha1 = "068fda9b756e41e6c75da7b771e6f89fa8a43d15"
+git-tree-sha1 = "01ca3823217f474243cc2c8e6e1d1f45956fe872"
 uuid = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
-version = "0.7.0"
+version = "1.0.0"
 
 [[Bzip2_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
 git-tree-sha1 = "19a35467a82e236ff51bc17a3a44b69ef35185a2"
 uuid = "6e34b625-4abd-537c-b88f-471c36dfa7a0"
 version = "1.0.8+0"
+
+[[ChainRulesCore]]
+deps = ["Compat", "LinearAlgebra", "SparseArrays"]
+git-tree-sha1 = "4b28f88cecf5d9a07c85b9ce5209a361ecaff34a"
+uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+version = "0.9.45"
 
 [[CodecBzip2]]
 deps = ["Bzip2_jll", "Libdl", "TranscodingStreams"]
@@ -33,15 +39,50 @@ git-tree-sha1 = "ded953804d019afa9a3f98981d99b33e3db7b6da"
 uuid = "944b1d66-785c-5afd-91f1-9de20f533193"
 version = "0.7.0"
 
+[[Compat]]
+deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "SHA", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
+git-tree-sha1 = "e4e2b39db08f967cc1360951f01e8a75ec441cab"
+uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
+version = "3.30.0"
+
+[[CompilerSupportLibraries_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+
+[[DataAPI]]
+git-tree-sha1 = "dfb3b7e89e395be1e25c2ad6d7690dc29cc53b1d"
+uuid = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
+version = "1.6.0"
+
+[[DataStructures]]
+deps = ["Compat", "InteractiveUtils", "OrderedCollections"]
+git-tree-sha1 = "4437b64df1e0adccc3e5d1adbc3ac741095e4677"
+uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+version = "0.18.9"
+
 [[Dates]]
 deps = ["Printf"]
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[DelimitedFiles]]
+deps = ["Mmap"]
+uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 
 [[Distances]]
 deps = ["LinearAlgebra", "Statistics", "StatsAPI"]
 git-tree-sha1 = "abe4ad222b26af3337262b8afb28fab8d215e9f8"
 uuid = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 version = "0.10.3"
+
+[[Distributed]]
+deps = ["Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
+[[Distributions]]
+deps = ["FillArrays", "LinearAlgebra", "PDMats", "Printf", "QuadGK", "Random", "SparseArrays", "SpecialFunctions", "Statistics", "StatsBase", "StatsFuns"]
+git-tree-sha1 = "64a3e756c44dcf33bd33e7f500113d9992a02e92"
+uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
+version = "0.25.2"
 
 [[DocStringExtensions]]
 deps = ["LibGit2", "Markdown", "Pkg", "Test"]
@@ -59,11 +100,17 @@ version = "0.26.3"
 deps = ["ArgTools", "LibCURL", "NetworkOptions"]
 uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 
+[[FillArrays]]
+deps = ["LinearAlgebra", "Random", "SparseArrays"]
+git-tree-sha1 = "31939159aeb8ffad1d4d8ee44d07f8558273120a"
+uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
+version = "0.11.7"
+
 [[HTTP]]
 deps = ["Base64", "Dates", "IniFile", "MbedTLS", "NetworkOptions", "Sockets", "URIs"]
-git-tree-sha1 = "b855bf8247d6e946c75bb30f593bfe7fe591058d"
+git-tree-sha1 = "86ed84701fbfd1142c9786f8e53c595ff5a4def9"
 uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
-version = "0.9.8"
+version = "0.9.10"
 
 [[IOCapture]]
 deps = ["Logging"]
@@ -134,6 +181,12 @@ git-tree-sha1 = "32b517d4d8219d3bbab199de3416ace45010bdb3"
 uuid = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
 version = "2.8.0"
 
+[[LogExpFunctions]]
+deps = ["DocStringExtensions", "LinearAlgebra"]
+git-tree-sha1 = "1ba664552f1ef15325e68dc4c05c3ef8c2d5d885"
+uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
+version = "0.2.4"
+
 [[Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
@@ -143,9 +196,9 @@ uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
 [[MathOptInterface]]
 deps = ["BenchmarkTools", "CodecBzip2", "CodecZlib", "JSON", "JSONSchema", "LinearAlgebra", "MutableArithmetics", "OrderedCollections", "SparseArrays", "Test", "Unicode"]
-git-tree-sha1 = "cd3057ca89a9ab83ce37ec42324523b8db0c60dc"
+git-tree-sha1 = "575644e3c05b258250bb599e57cf73bbf1062901"
 uuid = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
-version = "0.9.21"
+version = "0.9.22"
 
 [[MbedTLS]]
 deps = ["Dates", "MbedTLS_jll", "Random", "Sockets"]
@@ -156,6 +209,12 @@ version = "1.0.3"
 [[MbedTLS_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
+
+[[Missings]]
+deps = ["DataAPI"]
+git-tree-sha1 = "4ea90bd5d3985ae1f9a908bd4500ae88921c5ce7"
+uuid = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
+version = "1.0.0"
 
 [[Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
@@ -172,16 +231,28 @@ version = "0.2.19"
 [[NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
 
+[[OpenSpecFun_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "b9b8b8ed236998f91143938a760c2112dceeb2b4"
+uuid = "efe28fd5-8261-553b-a9e1-b2916fc3738e"
+version = "0.5.4+0"
+
 [[OptimalTransport]]
-deps = ["Distances", "IterativeSolvers", "LinearAlgebra", "MathOptInterface", "SparseArrays"]
+deps = ["Distances", "Distributions", "IterativeSolvers", "LinearAlgebra", "LogExpFunctions", "MathOptInterface", "QuadGK", "SparseArrays", "StatsBase"]
 path = ".."
 uuid = "7e02d93a-ae51-4f58-b602-d97af76e3b33"
-version = "0.3.0"
+version = "0.3.6"
 
 [[OrderedCollections]]
 git-tree-sha1 = "85f8e6578bf1f9ee0d11e7bb1b1456435479d47c"
 uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 version = "1.4.1"
+
+[[PDMats]]
+deps = ["LinearAlgebra", "SparseArrays", "SuiteSparse"]
+git-tree-sha1 = "f82a0e71f222199de8e9eb9a09977bd0767d52a0"
+uuid = "90014a1f-27ba-587c-ab20-58faa44d9150"
+version = "0.11.0"
 
 [[Parsers]]
 deps = ["Dates"]
@@ -203,6 +274,12 @@ version = "1.2.2"
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
+[[QuadGK]]
+deps = ["DataStructures", "LinearAlgebra"]
+git-tree-sha1 = "12fbe86da16df6679be7521dfb39fbc861e1dc7b"
+uuid = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
+version = "2.4.1"
+
 [[REPL]]
 deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
@@ -216,18 +293,46 @@ git-tree-sha1 = "b3fb709f3c97bfc6e948be68beeecb55a0b340ae"
 uuid = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 version = "1.1.1"
 
+[[Rmath]]
+deps = ["Random", "Rmath_jll"]
+git-tree-sha1 = "bf3188feca147ce108c76ad82c2792c57abe7b1f"
+uuid = "79098fc4-a85e-5d69-aa6a-4863f24498fa"
+version = "0.7.0"
+
+[[Rmath_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "68db32dff12bb6127bac73c209881191bf0efbb7"
+uuid = "f50d1b31-88e8-58de-be2c-1cc44531875f"
+version = "0.3.0+0"
+
 [[SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 
 [[Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 
+[[SharedArrays]]
+deps = ["Distributed", "Mmap", "Random", "Serialization"]
+uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
+
 [[Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[SortingAlgorithms]]
+deps = ["DataStructures"]
+git-tree-sha1 = "2ec1962eba973f383239da22e75218565c390a96"
+uuid = "a2af1166-a08f-5f64-846c-94a0d3cef48c"
+version = "1.0.0"
 
 [[SparseArrays]]
 deps = ["LinearAlgebra", "Random"]
 uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[SpecialFunctions]]
+deps = ["ChainRulesCore", "LogExpFunctions", "OpenSpecFun_jll"]
+git-tree-sha1 = "371204984184315ed7228bcc604d08e1bbc18f31"
+uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
+version = "1.4.2"
 
 [[Statistics]]
 deps = ["LinearAlgebra", "SparseArrays"]
@@ -237,6 +342,22 @@ uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 git-tree-sha1 = "1958272568dc176a1d881acb797beb909c785510"
 uuid = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
 version = "1.0.0"
+
+[[StatsBase]]
+deps = ["DataAPI", "DataStructures", "LinearAlgebra", "Missings", "Printf", "Random", "SortingAlgorithms", "SparseArrays", "Statistics", "StatsAPI"]
+git-tree-sha1 = "2f6792d523d7448bbe2fec99eca9218f06cc746d"
+uuid = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+version = "0.33.8"
+
+[[StatsFuns]]
+deps = ["LogExpFunctions", "Rmath", "SpecialFunctions"]
+git-tree-sha1 = "30cd8c360c54081f806b1ee14d2eecbef3c04c49"
+uuid = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
+version = "0.9.8"
+
+[[SuiteSparse]]
+deps = ["Libdl", "LinearAlgebra", "Serialization", "SparseArrays"]
+uuid = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
 
 [[TOML]]
 deps = ["Dates"]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,9 +1,11 @@
 [deps]
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
 OptimalTransport = "7e02d93a-ae51-4f58-b602-d97af76e3b33"
 
 [compat]
+Distributions = "0.25"
 Documenter = "0.26"
 Literate = "2.8"
 OptimalTransport = "0.3"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,4 +1,6 @@
 using OptimalTransport
+using Distributions
+
 using Literate: Literate
 using Pkg: Pkg
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -8,6 +8,8 @@ emd
 emd2
 ot_plan
 ot_cost
+wasserstein
+squared2wasserstein
 ```
 
 ## Entropically regularised optimal transport

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -7,7 +7,11 @@
 emd
 emd2
 ot_plan
+ot_plan(::Any, ::ContinuousUnivariateDistribution, ::UnivariateDistribution)
+ot_plan(::Any, ::DiscreteNonParametric, ::DiscreteNonParametric)
 ot_cost
+ot_cost(::Any, ::ContinuousUnivariateDistribution, ::UnivariateDistribution)
+ot_cost(::Any, ::DiscreteNonParametric, ::DiscreteNonParametric)
 wasserstein
 squared2wasserstein
 ```

--- a/src/OptimalTransport.jl
+++ b/src/OptimalTransport.jl
@@ -17,9 +17,12 @@ export emd, emd2
 export sinkhorn_stabilized, sinkhorn_stabilized_epsscaling, sinkhorn_barycenter
 export sinkhorn_unbalanced, sinkhorn_unbalanced2
 export quadreg
-export ot_cost, ot_plan
+export ot_cost, ot_plan, wasserstein, squared2wasserstein
 
 const MOI = MathOptInterface
+
+include("exact.jl")
+include("wasserstein.jl")
 
 dot_matwise(x::AbstractMatrix, y::AbstractMatrix) = dot(x, y)
 function dot_matwise(x::AbstractArray, y::AbstractMatrix)
@@ -877,64 +880,6 @@ function quadreg(mu, nu, C, ϵ; θ=0.1, tol=1e-5, maxiter=50, κ=0.5, δ=1e-5)
     end
 
     return sparse(γ')
-end
-
-"""
-    ot_cost(
-        c, μ::ContinuousUnivariateDistribution, ν::UnivariateDistribution; plan=nothing
-    )
-
-Compute the optimal transport cost for the Monge-Kantorovich problem with univariate
-distributions `μ` and `ν` as source and target marginals and cost function `c` of
-the form ``c(x, y) = h(|x - y|)`` where ``h`` is a convex function.
-
-In this setting, the optimal transport cost can be computed as
-```math
-\\int_0^1 c(F_\\mu^{-1}(x), F_\\nu^{-1}(x)) \\mathrm{d}x
-```
-where ``F_\\mu^{-1}`` and ``F_\\nu^{-1}`` are the quantile functions of `μ` and `ν`,
-respectively.
-
-A pre-computed optimal transport `plan` may be provided.
-
-See also: [`ot_plan`](@ref), [`emd2`](@ref)
-"""
-function ot_cost(
-    c, μ::ContinuousUnivariateDistribution, ν::UnivariateDistribution; plan=nothing
-)
-    cost, _ = if plan === nothing
-        quadgk(0, 1) do q
-            return c(quantile(μ, q), quantile(ν, q))
-        end
-    else
-        quadgk(0, 1) do q
-            x = quantile(μ, q)
-            return c(x, plan(x))
-        end
-    end
-    return cost
-end
-
-"""
-    ot_plan(c, μ::ContinuousUnivariateDistribution, ν::UnivariateDistribution)
-
-Compute the optimal transport plan for the Monge-Kantorovich problem with univariate
-distributions `μ` and `ν` as source and target marginals and cost function `c` of
-the form ``c(x, y) = h(|x - y|)`` where ``h`` is a convex function.
-
-In this setting, the optimal transport plan is the Monge map
-```math
-T = F_\\nu^{-1} \\circ F_\\mu
-```
-where ``F_\\mu`` is the cumulative distribution function of `μ` and ``F_\\nu^{-1}`` is the
-quantile function of `ν`.
-
-See also: [`ot_cost`](@ref), [`emd`](@ref)
-"""
-function ot_plan(c, μ::ContinuousUnivariateDistribution, ν::UnivariateDistribution)
-    # Use T instead of γ to indicate that this is a Monge map.
-    T(x) = quantile(ν, cdf(μ, x))
-    return T
 end
 
 end

--- a/src/exact.jl
+++ b/src/exact.jl
@@ -12,7 +12,7 @@ where ``\\Pi(\\mu, \\nu)`` denotes the couplings of ``\\mu`` and ``\\nu``.
 
 See also: [`ot_cost`](@ref)
 """
-ot_plan
+function ot_plan end
 
 """
     ot_cost(c, μ, ν; kwargs...)
@@ -28,7 +28,7 @@ where ``\\Pi(\\mu, \\nu)`` denotes the couplings of ``\\mu`` and ``\\nu``.
 
 See also: [`ot_plan`](@ref)
 """
-ot_cost
+function ot_cost end
 
 #############
 # Discrete OT

--- a/src/exact.jl
+++ b/src/exact.jl
@@ -1,0 +1,89 @@
+"""
+    ot_plan(c, μ, ν; kwargs...)
+
+Compute the optimal transport plan for the Monge-Kantorovich problem with source and target
+marginals `μ` and `ν` and cost `c`.
+
+The optimal transport plan solves
+```math
+\\inf_{\\gamma \\in \\Pi(\\mu, \\nu)} \\int c(x, y) \\, \\mathrm{d}\\gamma(x, y)
+```
+where ``\\Pi(\\mu, \\nu)`` denotes the couplings of ``\\mu`` and ``\\nu``.
+
+See also: [`ot_cost`](@ref)
+"""
+ot_plan
+
+"""
+    ot_cost(c, μ, ν; kwargs...)
+
+Compute the optimal transport cost for the Monge-Kantorovich problem with source and target
+marginals `μ` and `ν` and cost `c`.
+
+The optimal transport cost is the scalar value
+```math
+\\inf_{\\gamma \\in \\Pi(\\mu, \\nu)} \\int c(x, y) \\, \\mathrm{d}\\gamma(x, y)
+```
+where ``\\Pi(\\mu, \\nu)`` denotes the couplings of ``\\mu`` and ``\\nu``.
+
+See also: [`ot_plan`](@ref)
+"""
+ot_cost
+
+"""
+    ot_cost(
+        c, μ::ContinuousUnivariateDistribution, ν::UnivariateDistribution; plan=nothing
+    )
+
+Compute the optimal transport cost for the Monge-Kantorovich problem with univariate
+distributions `μ` and `ν` as source and target marginals and cost function `c` of
+the form ``c(x, y) = h(|x - y|)`` where ``h`` is a convex function.
+
+In this setting, the optimal transport cost can be computed as
+```math
+\\int_0^1 c(F_\\mu^{-1}(x), F_\\nu^{-1}(x)) \\mathrm{d}x
+```
+where ``F_\\mu^{-1}`` and ``F_\\nu^{-1}`` are the quantile functions of `μ` and `ν`,
+respectively.
+
+A pre-computed optimal transport `plan` may be provided.
+
+See also: [`ot_plan`](@ref), [`emd2`](@ref)
+"""
+function ot_cost(
+    c, μ::ContinuousUnivariateDistribution, ν::UnivariateDistribution; plan=nothing
+)
+    cost, _ = if plan === nothing
+        quadgk(0, 1) do q
+            return c(quantile(μ, q), quantile(ν, q))
+        end
+    else
+        quadgk(0, 1) do q
+            x = quantile(μ, q)
+            return c(x, plan(x))
+        end
+    end
+    return cost
+end
+
+"""
+    ot_plan(c, μ::ContinuousUnivariateDistribution, ν::UnivariateDistribution)
+
+Compute the optimal transport plan for the Monge-Kantorovich problem with univariate
+distributions `μ` and `ν` as source and target marginals and cost function `c` of
+the form ``c(x, y) = h(|x - y|)`` where ``h`` is a convex function.
+
+In this setting, the optimal transport plan is the Monge map
+```math
+T = F_\\nu^{-1} \\circ F_\\mu
+```
+where ``F_\\mu`` is the cumulative distribution function of `μ` and ``F_\\nu^{-1}`` is the
+quantile function of `ν`.
+
+See also: [`ot_cost`](@ref), [`emd`](@ref)
+"""
+function ot_plan(c, μ::ContinuousUnivariateDistribution, ν::UnivariateDistribution)
+    # Use T instead of γ to indicate that this is a Monge map.
+    T(x) = quantile(ν, cdf(μ, x))
+    return T
+end

--- a/src/wasserstein.jl
+++ b/src/wasserstein.jl
@@ -1,0 +1,39 @@
+"""
+    wasserstein(μ, ν; metric=Euclidean(), p=Val(1), kwargs...)
+
+Compute the `p`-Wasserstein distance with respect to the `metric` between measures `μ` and
+`ν`.
+
+The remaining keyword arguments are forwarded to [`ot_cost`](@ref).
+
+See also: [`squared2wasserstein`](@ref), [`ot_cost`](@ref)
+"""
+function wasserstein(μ, ν; metric=Euclidean(), p::Val=Val(1), kwargs...)
+    cost = ot_cost(p2distance(metric, p), μ, ν; kwargs...)
+    return prt(cost, p)
+end
+
+# compute the cost function corresponding to a metric and exponent `p`
+p2distance(metric, ::Val{1}) = metric
+p2distance(metric, ::Val{P}) where {P} = (x, y) -> metric(x, y)^P
+p2distance(d::Euclidean, ::Val{2}) = SqEuclidean(d.thresh)
+
+# compute the `p` root
+prt(x, ::Val{1}) = x
+prt(x, ::Val{2}) = sqrt(x)
+prt(x, ::Val{3}) = cbrt(x)
+prt(x, ::Val{P}) where {P} = x^(1 / P)
+
+"""
+    squared2wasserstein(μ, ν; metric=Euclidean(), kwargs...)
+
+Compute the squared 2-Wasserstein distance with respect to the `metric` between measures `μ`
+and `ν`.
+
+The remaining keyword arguments are forwarded to [`ot_cost`](@ref).
+
+See also: [`wasserstein`](@ref), [`ot_cost`](@ref)
+"""
+function squared2wasserstein(μ, ν; metric=Euclidean(), kwargs...)
+    return ot_cost(p2distance(metric, Val(2)), μ, ν; kwargs...)
+end

--- a/src/wasserstein.jl
+++ b/src/wasserstein.jl
@@ -4,11 +4,14 @@
 Compute the `p`-Wasserstein distance with respect to the `metric` between measures `μ` and
 `ν`.
 
-The remaining keyword arguments are forwarded to [`ot_cost`](@ref).
+Order `p` can be provided as a scalar of type `Real` or as a parameter of a value type
+`Val(p)`. For certain combinations of `metric` and `p`, such as `metric=Euclidean()` and
+`p=Val(2)`, the computations are more efficient if `p` is specified as a value type. The
+remaining keyword arguments are forwarded to [`ot_cost`](@ref).
 
 See also: [`squared2wasserstein`](@ref), [`ot_cost`](@ref)
 """
-function wasserstein(μ, ν; metric=Euclidean(), p::Val=Val(1), kwargs...)
+function wasserstein(μ, ν; metric=Euclidean(), p::Union{Real,Val}=Val(1), kwargs...)
     cost = ot_cost(p2distance(metric, p), μ, ν; kwargs...)
     return prt(cost, p)
 end
@@ -17,12 +20,14 @@ end
 p2distance(metric, ::Val{1}) = metric
 p2distance(metric, ::Val{P}) where {P} = (x, y) -> metric(x, y)^P
 p2distance(d::Euclidean, ::Val{2}) = SqEuclidean(d.thresh)
+p2distance(metric, p) = (x, y) -> metric(x, y)^p
 
 # compute the `p` root
 prt(x, ::Val{1}) = x
 prt(x, ::Val{2}) = sqrt(x)
 prt(x, ::Val{3}) = cbrt(x)
 prt(x, ::Val{P}) where {P} = x^(1 / P)
+prt(x, p) = x^(1 / p)
 
 """
     squared2wasserstein(μ, ν; metric=Euclidean(), kwargs...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,6 +20,9 @@ const GROUP = get(ENV, "GROUP", "All")
         @safetestset "Unbalanced OT" begin
             include("unbalanced.jl")
         end
+        @safetestset "Wasserstein distance" begin
+            include("wasserstein.jl")
+        end
     end
 
     # CUDA requires Julia >= 1.6

--- a/test/wasserstein.jl
+++ b/test/wasserstein.jl
@@ -21,14 +21,17 @@ Random.seed!(100)
         x = randn(10)
         y = randn(10)
         for metric in (Euclidean(), TotalVariation())
-            pmetric = OptimalTransport.p2distance(metric, Val(p))
-            @test pmetric(x, y) ≈ metric(x, y)^p
+            for _p in (p, Val(p))
+                pmetric = OptimalTransport.p2distance(metric, _p)
+                @test pmetric(x, y) ≈ metric(x, y)^p
+            end
         end
     end
 
     @testset "prt" begin
         x = randexp()
         for p in (1, 2, 3, randexp())
+            @test OptimalTransport.prt(x, p) ≈ x^(1 / p)
             @test OptimalTransport.prt(x, Val(p)) ≈ x^(1 / p)
         end
     end
@@ -37,20 +40,22 @@ Random.seed!(100)
         μ = Normal(randn(), randexp())
         ν = Normal(randn(), randexp())
         for p in (1, 2, 3, randexp()), metric in (Euclidean(), TotalVariation())
-            # without additional keyword arguments
-            w = wasserstein(μ, ν; p=Val(p), metric=metric)
-            @test w ≈ ot_cost((x, y) -> metric(x, y)^p, μ, ν)^(1 / p)
+            for _p in (p, Val(p))
+                # without additional keyword arguments
+                w = wasserstein(μ, ν; p=_p, metric=metric)
+                @test w ≈ ot_cost((x, y) -> metric(x, y)^p, μ, ν)^(1 / p)
 
-            # with pre-computed plan (random `ν` ensures that plan is used)
-            T = ot_plan((x, y) -> metric(x, y)^p, μ, ν)
-            w2 = wasserstein(μ, Normal(randn(), rand()); p=Val(p), metric=metric, plan=T)
-            @test w ≈ w2
+                # with pre-computed plan (random `ν` ensures that plan is used)
+                T = ot_plan((x, y) -> metric(x, y)^p, μ, ν)
+                w2 = wasserstein(μ, Normal(randn(), rand()); p=_p, metric=metric, plan=T)
+                @test w ≈ w2
+            end
         end
 
         # check that `Euclidean` is the default `metric`
-        for p in (1, 2, 3, randexp())
-            w = wasserstein(μ, ν; p=Val(p))
-            @test w ≈ wasserstein(μ, ν; p=Val(p), metric=Euclidean())
+        for p in (1, 2, 3, randexp()), _p in (p, Val(p))
+            w = wasserstein(μ, ν; p=_p)
+            @test w ≈ wasserstein(μ, ν; p=_p, metric=Euclidean())
         end
 
         # check that `Val(1)` is the default `p`

--- a/test/wasserstein.jl
+++ b/test/wasserstein.jl
@@ -1,0 +1,81 @@
+using OptimalTransport
+
+using Distances
+using Distributions
+
+using Random
+using Test
+
+Random.seed!(100)
+
+@testset "wasserstein.jl" begin
+    @testset "p2distance" begin
+        for metric in (Euclidean(), Euclidean(0.01), TotalVariation())
+            @test OptimalTransport.p2distance(metric, Val(1)) === metric
+        end
+
+        @test OptimalTransport.p2distance(Euclidean(), Val(2)) == SqEuclidean()
+        @test OptimalTransport.p2distance(Euclidean(0.01), Val(2)) == SqEuclidean(0.01)
+
+        p = randexp()
+        x = randn(10)
+        y = randn(10)
+        for metric in (Euclidean(), TotalVariation())
+            pmetric = OptimalTransport.p2distance(metric, Val(p))
+            @test pmetric(x, y) ≈ metric(x, y)^p
+        end
+    end
+
+    @testset "prt" begin
+        x = randexp()
+        for p in (1, 2, 3, randexp())
+            @test OptimalTransport.prt(x, Val(p)) ≈ x^(1 / p)
+        end
+    end
+
+    @testset "wasserstein" begin
+        μ = Normal(randn(), randexp())
+        ν = Normal(randn(), randexp())
+        for p in (1, 2, 3, randexp()), metric in (Euclidean(), TotalVariation())
+            # without additional keyword arguments
+            w = wasserstein(μ, ν; p=Val(p), metric=metric)
+            @test w ≈ ot_cost((x, y) -> metric(x, y)^p, μ, ν)^(1 / p)
+
+            # with pre-computed plan (random `ν` ensures that plan is used)
+            T = ot_plan((x, y) -> metric(x, y)^p, μ, ν)
+            w2 = wasserstein(μ, Normal(randn(), rand()); p=Val(p), metric=metric, plan=T)
+            @test w ≈ w2
+        end
+
+        # check that `Euclidean` is the default `metric`
+        for p in (1, 2, 3, randexp())
+            w = wasserstein(μ, ν; p=Val(p))
+            @test w ≈ wasserstein(μ, ν; p=Val(p), metric=Euclidean())
+        end
+
+        # check that `Val(1)` is the default `p`
+        for metric in (Euclidean(), TotalVariation())
+            w = wasserstein(μ, ν; metric=metric)
+            @test w ≈ wasserstein(μ, ν; p=Val(1), metric=metric)
+        end
+    end
+
+    @testset "squared2wasserstein" begin
+        μ = Normal(randn(), randexp())
+        ν = Normal(randn(), randexp())
+        for metric in (Euclidean(), TotalVariation())
+            # without additional keyword arguments
+            w = squared2wasserstein(μ, ν; metric=metric)
+            @test w ≈ ot_cost((x, y) -> metric(x, y)^2, μ, ν)
+
+            # with pre-computed plan (random `ν` ensures that plan is used)
+            T = ot_plan((x, y) -> metric(x, y)^2, μ, ν)
+            w2 = squared2wasserstein(μ, Normal(randn(), rand()); metric=metric, plan=T)
+            @test w ≈ w2
+        end
+
+        # check that `Euclidean` is the default `metric`
+        w = squared2wasserstein(μ, ν)
+        @test w ≈ squared2wasserstein(μ, ν; metric=Euclidean())
+    end
+end


### PR DESCRIPTION
Add `wasserstein` and `squared2wasserstein` functions that compute the p-Wasserstein distance and the squared 2-Wasserstein distance.

https://github.com/JuliaOptimalTransport/OptimalTransport.jl/pull/88 and https://github.com/JuliaOptimalTransport/OptimalTransport.jl/pull/85 will add support for more types of marginals.