### PR TITLE
Added a warning to the discretemeasure function

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -101,6 +101,12 @@ function discretemeasure(
     support::AbstractVector,
     probs::AbstractVector{<:Real}=fill(inv(length(support)), length(support)),
 )
+    if length(support[1]) == 1
+        @warn """if your support is 1D, the correct format should be a vector
+        and not a vector of vector (e.g. `μsupp = [[0],[4.5],[2]]` should be
+        `μsupp = [0, 4.5, 2]`). You may use `reduce(vcat, μsupp)` to
+        flatten your vector of vectors, before passing it to `discretemeasure`."""
+    end
     return FiniteDiscreteMeasure{typeof(support),typeof(probs)}(support, probs)
 end
 


### PR DESCRIPTION
I noted that there is an "inconsistency" with our `discretemeasure` function. If I pass `musupp = [[0],[1],[2]]`, the function is dispatched to the multivariate case, instead of passing to the `DiscreteNonParametric`. I can see why that is, since the type required would be a vector, and not a vector of vectors.

I've been trying to fix this issue, but all solutions I came up with require that we check the length of the vector inside the vectors of vectors. And I'm guessing this would cause instabilities to the compiler (this is a supposition based on past code I wrote that @devmotion required changes).

So instead, I decided to add a warning inside the `discretemeasure` function, so that the user is informed that he should not pass a vector of 1D vectors, and should instead flatten into a single vector in case his support is 1D.