### PR TITLE
Simplify GPU test environment

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -14,3 +14,4 @@ steps:
 
 env:
   GROUP: GPU
+  JULIA_DEBUG: CUBLAS

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -14,4 +14,3 @@ steps:
 
 env:
   GROUP: GPU
-  JULIA_DEBUG: CUBLAS

--- a/test/gpu/Project.toml
+++ b/test/gpu/Project.toml
@@ -1,12 +1,6 @@
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
-Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
-LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-OptimalTransport = "7e02d93a-ae51-4f58-b602-d97af76e3b33"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 CUDA = "3"
-Distances = "0.10"
-OptimalTransport = "0.3"
 julia = "1.6"

--- a/test/gpu/Project.toml
+++ b/test/gpu/Project.toml
@@ -2,5 +2,5 @@
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 
 [compat]
-CUDA = "3"
+CUDA = "= 3.2"
 julia = "1.6"

--- a/test/gpu/Project.toml
+++ b/test/gpu/Project.toml
@@ -2,5 +2,5 @@
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 
 [compat]
-CUDA = "= 3.2"
+CUDA = "3"
 julia = "1.6"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,6 +41,7 @@ const GROUP = get(ENV, "GROUP", "All")
         # activate separate environment: CUDA can't be added to test/Project.toml since it
         # is not available on older Julia versions
         Pkg.activate("gpu")
+        Pkg.add(Pkg.PackageSpec(; name="CUDA", rev="master"))
         Pkg.instantiate()
 
         @safetestset "Simple GPU" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,7 +41,6 @@ const GROUP = get(ENV, "GROUP", "All")
         # activate separate environment: CUDA can't be added to test/Project.toml since it
         # is not available on older Julia versions
         Pkg.activate("gpu")
-        Pkg.add(Pkg.PackageSpec(; name="CUDA", rev="master"))
         Pkg.instantiate()
 
         @safetestset "Simple GPU" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,9 +40,7 @@ const GROUP = get(ENV, "GROUP", "All")
     if (GROUP == "All" || GROUP == "GPU") && VERSION >= v"1.6"
         # activate separate environment: CUDA can't be added to test/Project.toml since it
         # is not available on older Julia versions
-        pkgdir = dirname(dirname(pathof(OptimalTransport)))
         Pkg.activate("gpu")
-        Pkg.develop(Pkg.PackageSpec(; path=pkgdir))
         Pkg.instantiate()
 
         @safetestset "Simple GPU" begin


### PR DESCRIPTION
This PR is used for debugging (and possibly fixing) the GPU errors we see lately.

I should add that the tests pass locally with CUDA 3.3.0.