### PR TITLE
Quad gpu fix

### DIFF
--- a/src/quadratic_newton.jl
+++ b/src/quadratic_newton.jl
@@ -19,6 +19,7 @@ end
     QuadraticOTNewton(;θ = 0.1, κ = 0.5, δ = 1e-5, armijo_max = 50)
 
 Semi-smooth Newton method (Algorithm 2 of Lorenz et al. 2019) with Armijo parameters `θ` and `κ`, and conjugate gradient regularisation `δ`. 
+`armijo_max` sets the maximum number of Armijo step size trials.
 
 See also: [`QuadraticOTNewton`](@ref), [`quadreg`](@ref)
 """

--- a/src/quadratic_newton.jl
+++ b/src/quadratic_newton.jl
@@ -22,7 +22,7 @@ Semi-smooth Newton method (Algorithm 2 of Lorenz et al. 2019) with Armijo parame
 
 See also: [`QuadraticOTNewton`](@ref), [`quadreg`](@ref)
 """
-function QuadraticOTNewton(; θ=0.1, κ=0.5, δ=1e-5, armijo_max = 50)
+function QuadraticOTNewton(; θ=0.1, κ=0.5, δ=1e-5, armijo_max=50)
     return QuadraticOTNewton(θ, κ, δ, armijo_max)
 end
 
@@ -159,7 +159,8 @@ function descent_step!(solver::QuadraticOTSolver{<:QuadraticOTNewton})
     d = -eps * (dot(δu, μ) + dot(δv, ν)) + eps * dot(γ, δu .+ δv')
     t = 1
     Φ0 = Φ(u, v, μ, ν, C, eps)
-    while (armijo_counter < armijo_max) && (Φ(u + t * δu, v + t * δv, μ, ν, C, eps) ≥ Φ0 + t * θ * d)
+    while (armijo_counter < armijo_max) &&
+        (Φ(u + t * δu, v + t * δv, μ, ν, C, eps) ≥ Φ0 + t * θ * d)
         t = κ * t
         armijo_counter += 1
     end

--- a/test/gpu/simple_gpu.jl
+++ b/test/gpu/simple_gpu.jl
@@ -96,10 +96,11 @@ Random.seed!(100)
 
         @testset "quadreg" begin
             # use a different reg parameter
-            ε_quad = 1f0 
+            ε_quad = 1.0f0
             γ = quadreg(cu_μ, cu_ν, cu_C, ε_quad, QuadraticOTNewton(0.1f0, 0.5f0, 1f-5, 50))
             # compare with results on the CPU
-            @test convert(Array, γ) ≈ quadreg(μ, ν, C, ε_quad, QuadraticOTNewton(0.1f0, 0.5f0, 1f-5, 50))
+            @test convert(Array, γ) ≈
+                  quadreg(μ, ν, C, ε_quad, QuadraticOTNewton(0.1f0, 0.5f0, 1f-5, 50))
         end
     end
 end

--- a/test/gpu/simple_gpu.jl
+++ b/test/gpu/simple_gpu.jl
@@ -100,7 +100,8 @@ Random.seed!(100)
             γ = quadreg(cu_μ, cu_ν, cu_C, ε_quad, QuadraticOTNewton(0.1f0, 0.5f0, 1f-5, 50))
             # compare with results on the CPU
             @test convert(Array, γ) ≈
-                  quadreg(μ, ν, C, ε_quad, QuadraticOTNewton(0.1f0, 0.5f0, 1f-5, 50))
+                  quadreg(μ, ν, C, ε_quad, QuadraticOTNewton(0.1f0, 0.5f0, 1f-5, 50)) atol =
+                1f-6 rtol = 1f-6
         end
     end
 end

--- a/test/gpu/simple_gpu.jl
+++ b/test/gpu/simple_gpu.jl
@@ -96,12 +96,13 @@ Random.seed!(100)
 
         @testset "quadreg" begin
             # use a different reg parameter
+            ENV["JULIA_DEBUG"] = "OptimalTransport"
             ε_quad = 1.0f0
             γ = quadreg(cu_μ, cu_ν, cu_C, ε_quad, QuadraticOTNewton(0.1f0, 0.5f0, 1f-5, 50))
             # compare with results on the CPU
             @test convert(Array, γ) ≈
                   quadreg(μ, ν, C, ε_quad, QuadraticOTNewton(0.1f0, 0.5f0, 1f-5, 50)) atol =
-                1f-5 rtol = 1f-5
+                1f-4 rtol = 1f-4
         end
     end
 end

--- a/test/gpu/simple_gpu.jl
+++ b/test/gpu/simple_gpu.jl
@@ -93,5 +93,13 @@ Random.seed!(100)
             @test convert(Array, γ) ≈ sinkhorn_unbalanced(μscaled, ν, C, λ1, λ2, ε)
             @test c ≈ sinkhorn_unbalanced2(μscaled, ν, C, λ1, λ2, ε)
         end
+
+        @testset "quadreg" begin
+            # use a different reg parameter
+            ε_quad = 1f0 
+            γ = quadreg(cu_μ, cu_ν, cu_C, ε_quad, QuadraticOTNewton(0.1f0, 0.5f0, 1f-5, 50))
+            # compare with results on the CPU
+            @test convert(Array, γ) ≈ quadreg(μ, ν, C, ε_quad, QuadraticOTNewton(0.1f0, 0.5f0, 1f-5, 50))
+        end
     end
 end

--- a/test/gpu/simple_gpu.jl
+++ b/test/gpu/simple_gpu.jl
@@ -101,7 +101,7 @@ Random.seed!(100)
             # compare with results on the CPU
             @test convert(Array, γ) ≈
                   quadreg(μ, ν, C, ε_quad, QuadraticOTNewton(0.1f0, 0.5f0, 1f-5, 50)) atol =
-                1f-6 rtol = 1f-6
+                1f-5 rtol = 1f-5
         end
     end
 end

--- a/test/gpu/simple_gpu.jl
+++ b/test/gpu/simple_gpu.jl
@@ -96,7 +96,6 @@ Random.seed!(100)
 
         @testset "quadreg" begin
             # use a different reg parameter
-            ENV["JULIA_DEBUG"] = "OptimalTransport"
             ε_quad = 1.0f0
             γ = quadreg(cu_μ, cu_ν, cu_C, ε_quad, QuadraticOTNewton(0.1f0, 0.5f0, 1f-5, 50))
             # compare with results on the CPU


### PR DESCRIPTION
This PR fixes type issues that prevent `quadreg` from running with CuArrays, and adds a test for that setting.
Also fixes a bug with the Armijo step search which I found for certain inputs caused the solver to get stuck.