### PR TITLE
Update Compat Bounds for NNlib

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 ExactOptimalTransport = "0.1, 0.2"
 IterativeSolvers = "0.8.4, 0.9"
 LogExpFunctions = "0.2, 0.3"
-NNlib = "0.6, 0.7, 0.8"
+NNlib = "0.6, 0.7, 0.8, 0.9"
 Reexport = "1"
 julia = "1"
 

--- a/test/gpu/Project.toml
+++ b/test/gpu/Project.toml
@@ -1,8 +1,8 @@
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
-NNlibCUDA = "a00861dc-f156-4864-bf3c-e6376f28a68d"
+NNlib = "872c559c-99b0-510c-b3b7-b6c96a88d5cd"
 
 [compat]
-CUDA = "3"
-NNlibCUDA = "0.2"
+CUDA = "5"
+NNlib = "0.9"
 julia = "1.6"

--- a/test/gpu/simple_gpu.jl
+++ b/test/gpu/simple_gpu.jl
@@ -2,7 +2,7 @@ using OptimalTransport
 
 using CUDA
 using Distances
-using NNlibCUDA
+using NNlib
 
 using LinearAlgebra
 using Random


### PR DESCRIPTION
I've updated the compat bounds for NNlib to allow v0.9

I've also fixed an issue with the GPU tests where the test environment was erroring because it required an old version of CUDA and NNlibCUDA (which has been deprecated in favor of a CUDA extension in NNlib).  

Please note: I have not been able to verify that the GPU tests run, since I do not have access to CUDA on my development machine.  