### PR TITLE
Add high-dimensional Gaussian Bures-Wasserstein utilities

### DIFF
--- a/src/OptimalTransport.jl
+++ b/src/OptimalTransport.jl
@@ -24,7 +24,12 @@ export sinkhorn_unbalanced, sinkhorn_unbalanced2
 export sinkhorn_divergence, sinkhorn_divergence_unbalanced
 export quadreg
 
+export bures_wasserstein_distance_hd, empirical_bures_wasserstein_distance_hd
+export bures_wasserstein_mapping_hd, empirical_bures_wasserstein_mapping_hd
+
 include("utils.jl")
+
+include("gaussian_hd.jl")
 
 include("entropic/sinkhorn.jl")
 include("entropic/sinkhorn_divergence.jl")

--- a/src/gaussian_hd.jl
+++ b/src/gaussian_hd.jl
@@ -1,0 +1,429 @@
+using LinearAlgebra
+
+"""
+    bures_wasserstein_mapping_hd(ms, mt, Us, Ut, ls, lt, sigma_s2, sigma_t2)
+
+Compute the optimal linear transport operator between two high-dimensional Gaussian distributions.
+
+This function estimates the linear operator M that maps the source Gaussian distribution 
+to the target Gaussian distribution, following the approach from Bouveyron & Corneli (2026), Theorem 2.10.
+
+The linear operator has the form:
+    M(x) = A * x + b
+
+where A is a linear transformation matrix and b is a translation vector.
+
+# Arguments
+- `ms::AbstractVector`: Mean vector of the source distribution (size p)
+- `mt::AbstractVector`: Mean vector of the target distribution (size p)
+- `Us::AbstractMatrix`: Orthogonal matrix spanning the principal subspace of the source distribution (size p × ds)
+- `Ut::AbstractMatrix`: Orthogonal matrix spanning the principal subspace of the target distribution (size p × dt)
+- `ls::AbstractVector`: Variances along the principal axes for the source distribution (size ds)
+- `lt::AbstractVector`: Variances along the principal axes for the target distribution (size dt)
+- `sigma_s2::Real`: Residual variance of the source distribution (scalar)
+- `sigma_t2::Real`: Residual variance of the target distribution (scalar)
+
+# Returns
+- `A::Matrix`: Linear transformation matrix (size p × p)
+- `b::Vector`: Translation/bias vector (size p)
+
+
+The optimal transport map is computed using a closed-form formula from Bouveyron & Corneli (2026), Theorem 2.10.
+
+# References
+- Knott, M. & Smith, C. S. (1984). "On the optimal mapping of distributions", 
+  Journal of Optimization Theory and Applications, Vol 43.
+  
+- Bouveyron, C. & Corneli, M. (2026). "Scaling Optimal Transport to High-Dimensional 
+  Gaussian Distributions".
+
+# Examples
+
+
+using LinearAlgebra
+
+p = 100
+ds = 10
+dt = 15
+
+ms = zeros(p)
+mt = ones(p)
+
+Us = Matrix(qr(randn(p, ds)).Q)
+Ut = Matrix(qr(randn(p, dt)).Q)
+
+ls = ones(ds)
+lt = 2 .* ones(dt)
+
+sigma_s2 = 0.1
+sigma_t2 = 0.2
+
+A, b = bures_wasserstein_mapping_hd(ms, mt, Us, Ut, ls, lt, sigma_s2, sigma_t2)
+
+x = randn(p)
+y = A * x + b
+"""
+function bures_wasserstein_mapping_hd(
+    ms::AbstractVector,
+    mt::AbstractVector,
+    Us::AbstractMatrix,
+    Ut::AbstractMatrix,
+    ls::AbstractVector,
+    lt::AbstractVector,
+    sigma_s2::Real,
+    sigma_t2::Real,
+)
+    sigma_s = sqrt(sigma_s2)
+
+    Cs = Diagonal(sqrt.(ls .+ sigma_s2) .- sigma_s)
+    Sigma_s_sqrt = Us * Cs * Us' + sigma_s * I
+
+    Ds = Diagonal((sqrt.(ls .+ sigma_s2) .- sigma_s) ./ sqrt.(ls .+ sigma_s2))
+    Sigma_s_invsqrt = (1 / sigma_s) * (I - Us * Ds * Us')
+
+    Sigma_t = Ut * Diagonal(lt) * Ut' + sigma_t2 * I
+
+    middle = sqrt(Symmetric(Sigma_s_sqrt * Sigma_t * Sigma_s_sqrt))
+
+    A = Sigma_s_invsqrt * middle * Sigma_s_invsqrt
+    b = mt - A * ms
+
+    return A, b
+end
+
+
+"""
+    empirical_bures_wasserstein_mapping_hd(xs, xt, d_intrinsic; reg=0.0, ws=nothing, wt=nothing, bias=true)
+
+Compute the high-dimensional (HD) Bures-Wasserstein optimal transport linear mapping between empirical samples.
+
+# Description
+
+This function estimates the optimal linear HD operator that aligns two empirical distributions. 
+It is equivalent to estimating the closed-form mapping between two HD Gaussian distributions.
+
+The linear operator from source to target is defined as:
+
+    M(x) = A * x + b
+
+where:
+- `A` is the linear operator matrix.
+- `b` is the bias vector.
+
+The matrices are computed using the following closed-form expressions:
+- `A = Sigma_s^{-1/2} * (Sigma_s^{1/2} * Sigma_t * Sigma_s^{1/2})^{1/2} * Sigma_s^{-1/2}`
+- `Sigma_s^{1/2} = sigma_s * I_p + U_s * C_s * U_s^T`
+- `C_s = diag(sqrt(l_s + sigma_s^2) - sigma_s)`
+- `Sigma_s^{-1/2} = (1 / sigma_s) * (I_p - U_s * D_s * U_s^T)`
+- `D_s = diag((sqrt(l_s + sigma_s^2) - sigma_s) / sqrt(l_s + sigma_s^2))`
+- `Sigma_t = U_t * diag(l_t) * U_t^T + sigma_t^2 * I_p`
+- `b = mu_t - A * mu_s`
+
+Assuming that the source and destination data samples have been generated from HD Gaussian 
+distributions, the probabilistic PCA estimators are used to estimate the model parameters 
+and plugged into the above formulas.
+
+# Arguments
+
+- `xs::AbstractMatrix`: Samples in the source domain (size: ns x p).
+- `xt::AbstractMatrix`: Samples in the target domain (size: nt x p).
+- `d_intrinsic::Union{Int, Tuple{Int, Int}}`: The intrinsic dimensions of the source and target 
+  distributions. If an `Int` is provided, the same intrinsic dimension is assumed for both.
+
+# Keyword Arguments
+
+- `reg::Real=0.0`: Regularization added to the diagonals of covariances.
+- `ws::Union{AbstractVector, Nothing}=nothing`: Weights for the source samples.
+- `wt::Union{AbstractVector, Nothing}=nothing`: Weights for the target samples.
+- `bias::Bool=true`: If `true`, estimates the bias `b`. If `false`, sets `b = 0`.
+
+# Returns
+
+- `A::Matrix`: The linear operator (size: p x p).
+- `b::Vector`: The bias vector (size: p).
+
+# References
+
+- [1] Bouveyron, C. & Corneli, M. "Scaling Optimal Transport to High-Dimensional Gaussian Distributions".
+- [2] Tipping, M.E. & Bishop, C.M. "Probabilistic Principal Component Analysis".
+"""
+function empirical_bures_wasserstein_mapping_hd(
+    xs::AbstractMatrix,
+    xt::AbstractMatrix,
+    d_intrinsic::Union{Int,Tuple{Int,Int}};
+    reg::Real=0.0,
+    ws::Union{AbstractVector,Nothing}=nothing,
+    wt::Union{AbstractVector,Nothing}=nothing,
+    bias::Bool=true,
+)
+    ds, dt = d_intrinsic isa Integer ? (d_intrinsic, d_intrinsic) : d_intrinsic
+
+    ns = size(xs, 1)
+    nt = size(xt, 1)
+    p = size(xs, 2)
+
+    if isnothing(ws)
+        ws = ones(eltype(xs), ns) ./ ns
+    end
+
+    if isnothing(wt)
+        wt = ones(eltype(xt), nt) ./ nt
+    end
+
+    if bias
+        mxs = vec(ws' * xs ./ sum(ws))
+        mxt = vec(wt' * xt ./ sum(wt))
+
+        xs = xs .- mxs'
+        xt = xt .- mxt'
+    else
+        mxs = zeros(eltype(xs), p)
+        mxt = zeros(eltype(xt), p)
+    end
+
+    Cs = (xs .* ws)' * xs ./ sum(ws) + reg * I
+    Ct = (xt .* wt)' * xt ./ sum(wt) + reg * I
+
+    eigs = eigen(Symmetric(Cs))
+    vals = reverse(eigs.values)
+    vecs = eigs.vectors[:, end:-1:1]
+
+    a_s = vals[1:ds]
+    sigma_2s = (tr(Cs) - sum(a_s)) / (p - ds)
+    Us = vecs[:, 1:ds]
+    ls = a_s .- sigma_2s
+
+    eigt = eigen(Symmetric(Ct))
+    valt = reverse(eigt.values)
+    vect = eigt.vectors[:, end:-1:1]
+
+    a_t = valt[1:dt]
+    sigma_2t = (tr(Ct) - sum(a_t)) / (p - dt)
+    Ut = vect[:, 1:dt]
+    lt = a_t .- sigma_2t
+
+    return bures_wasserstein_mapping_hd(mxs, mxt, Us, Ut, ls, lt, sigma_2s, sigma_2t)
+end
+
+
+"""
+    bures_wasserstein_distance_hd(ms, mt, Us, Ut, ls, lt, sigma_s2, sigma_t2)
+
+Compute the 2-Wasserstein distance between two high-dimensional Gaussian distributions.
+
+This function implements the closed-form formula from Bouveyron & Corneli (2026), Proposition 2.3,
+which allows computing the Wasserstein distance without explicitly forming the full covariance
+matrices, making it scalable to high dimensions.
+
+# Description
+
+The two Gaussian distributions are represented in a low-rank + diagonal form:
+
+    Source: N(ms, Sigma_s)  where  Sigma_s = Us * diag(ls) * Us' + sigma_s2 * I
+    Target: N(mt, Sigma_t)  where  Sigma_t = Ut * diag(lt) * Ut' + sigma_t2 * I
+
+The squared 2-Wasserstein distance is decomposed as:
+
+    W2^2 = ||ms - mt||^2
+         + tr(diag(ls))
+         + tr(diag(lt))
+         + p * (sigma_s2 + sigma_t2)
+         - 2 * tr( sqrt( Sigma_s^(1/2) * Sigma_t * Sigma_s^(1/2) ) )
+
+where Sigma_s^(1/2) is computed efficiently as:
+
+    Sigma_s^(1/2) = sqrt(sigma_s2) * I + Us * Cs * Us'
+
+and Cs is a diagonal matrix with entries:
+
+    Cs[i] = sqrt(ls[i] + sigma_s2) - sqrt(sigma_s2)
+
+# Arguments
+- ms::AbstractVector: Mean vector of the source distribution (size p)
+- mt::AbstractVector: Mean vector of the target distribution (size p)
+- Us::AbstractMatrix: Orthogonal matrix spanning the principal subspace of the source (size p × ds)
+- Ut::AbstractMatrix: Orthogonal matrix spanning the principal subspace of the target (size p × dt)
+- ls::AbstractVector: Variances along the principal axes of the source (size ds)
+- lt::AbstractVector: Variances along the principal axes of the target (size dt)
+- sigma_s2::Real: Residual (isotropic) variance of the source distribution
+- sigma_t2::Real: Residual (isotropic) variance of the target distribution
+
+# Returns
+- W::Real: The 2-Wasserstein distance between the two distributions
+
+# References
+- Knott, M. & Smith, C. S. (1984). "On the optimal mapping of distributions",
+  Journal of Optimization Theory and Applications, Vol 43.
+- Peyré, G. & Cuturi, M. (2019). "Computational Optimal Transport",
+  Foundations and Trends in Machine Learning.
+- Bouveyron, C. & Corneli, M. (2026). "Scaling Optimal Transport to
+  High-Dimensional Gaussian Distributions".
+
+# Example
+p = 100  # ambient dimension
+ds, dt = 10, 15  # intrinsic dimensions
+
+ms = zeros(p)
+Us = randn(p, ds)
+ls = abs.(randn(ds))
+sigma_s2 = 0.1
+
+mt = ones(p)
+Ut = randn(p, dt)
+lt = abs.(randn(dt))
+sigma_t2 = 0.2
+
+W2 = bures_wasserstein_distance_hd(ms, mt, Us, Ut, ls, lt, sigma_s2, sigma_t2)
+"""
+function bures_wasserstein_distance_hd(
+    ms::AbstractVector,
+    mt::AbstractVector,
+    Us::AbstractMatrix,
+    Ut::AbstractMatrix,
+    ls::AbstractVector,
+    lt::AbstractVector,
+    sigma_s2::Real,
+    sigma_t2::Real,
+)
+    p = size(Us, 1)
+
+    sigma_s = sqrt(sigma_s2)
+
+    Cs = Diagonal(sqrt.(ls .+ sigma_s2) .- sigma_s)
+    Sigma_s_sqrt = Us * Cs * Us' + sigma_s * I
+
+    Sigma_t = Ut * Diagonal(lt) * Ut' + sigma_t2 * I
+
+    middle = Sigma_s_sqrt * Sigma_t * Sigma_s_sqrt
+
+    W2 = (
+        sum(abs2, ms .- mt)
+        + sum(ls)
+        + sum(lt)
+        + p * (sigma_s2 + sigma_t2)
+        - 2 * tr(sqrt(Symmetric(middle)))
+    )
+
+    return sqrt(max(real(W2), zero(real(W2))))
+end
+
+
+
+
+"""
+    empirical_bures_wasserstein_distance_hd(xs, xt; d_intrinsic, reg=0.0, ws=nothing, wt=nothing, bias=true)
+
+Estimate the  2-Wasserstein distance between two high-dimensional Gaussian distributions from raw data samples.
+
+This function first estimates the parameters of the source and target Gaussian distributions 
+(means, principal subspaces, and variances) using Probabilistic PCA (PPCA), and then plugs 
+these estimates into the closed-form Bures-Wasserstein distance formula.
+
+# Description
+
+The squared 2-Wasserstein distance between the estimated distributions is computed as:
+
+    W2^2 = ||ms - mt||^2 
+         + tr(Ls) + tr(Lt) 
+         + p * (sigma_s2 + sigma_t2) 
+         - 2 * tr( sqrt( Sigma_s^(1/2) * Sigma_t * Sigma_s^(1/2) ) )
+
+where the covariance matrices are estimated via PPCA as:
+    Sigma_s = Us * diag(ls) * Us' + sigma_s2 * I
+    Sigma_t = Ut * diag(lt) * Ut' + sigma_t2 * I
+
+# Arguments
+- xs::AbstractMatrix: Samples from the source distribution (size ns x p)
+- xt::AbstractMatrix: Samples from the target distribution (size nt x p)
+- d_intrinsic::Union{Integer, Tuple{Integer, Integer}}`: The intrinsic dimension(s) of the distributions. 
+  If an integer is provided, the same intrinsic dimension is used for both source and target. 
+  If a tuple is provided, it specifies (ds, dt) respectively.
+- reg::Real: Regularization parameter added to the diagonal of the estimated covariances to ensure 
+  positive definiteness (default: 0.0).
+- ws::Union{AbstractVector, Nothing}: Optional weights for the source samples (default: nothing, uniform weights).
+- wt::Union{AbstractVector, Nothing}: Optional weights for the target samples (default: nothing, uniform weights).
+- bias::Bool: If true, estimates the means (ms, mt) from the data. If false, assumes the means are zero (default: true).
+
+# Returns
+- W::Real: The estimated 2-Wasserstein distance between the two distributions.
+
+# References
+- Bouveyron, C. & Corneli, M. (2024). "Scaling Optimal Transport to High-Dimensional Gaussian Distributions".
+- Tipping, M.E. & Bishop, C.M. (1999). "Probabilistic Principal Component Analysis", 
+  Journal of the Royal Statistical Society: Series B.
+
+# Example
+
+p = 100      # ambient dimension
+ns, nt = 500, 600  # number of samples
+ds, dt = 10, 15    # intrinsic dimensions
+
+# Generate dummy data
+xs = randn(ns, p)
+xt = randn(nt, p)
+
+# Compute empirical distance
+W2 = empirical_bures_wasserstein_distance_hd(xs, xt; d_intrinsic=(ds, dt), reg=1e-4)
+"""
+function empirical_bures_wasserstein_distance_hd(
+    xs::AbstractMatrix,
+    xt::AbstractMatrix;
+    d_intrinsic::Union{Integer,Tuple{<:Integer,<:Integer}},
+    reg::Real=0.0,
+    ws::Union{AbstractVector,Nothing}=nothing,
+    wt::Union{AbstractVector,Nothing}=nothing,
+    bias::Bool=true,
+)
+
+    ds, dt = d_intrinsic isa Integer ? (d_intrinsic, d_intrinsic) : d_intrinsic
+
+    ns = size(xs, 1)
+    nt = size(xt, 1)
+    p = size(xs, 2)
+
+    if isnothing(ws)
+        ws = ones(eltype(xs), ns) ./ ns
+    end
+
+    if isnothing(wt)
+        wt = ones(eltype(xt), nt) ./ nt
+    end
+
+    if bias
+        mxs = vec(ws' * xs ./ sum(ws))
+        mxt = vec(wt' * xt ./ sum(wt))
+
+        xs = xs .- mxs'
+        xt = xt .- mxt'
+    else
+        mxs = zeros(eltype(xs), p)
+        mxt = zeros(eltype(xt), p)
+    end
+
+    Cs = (xs .* ws)' * xs ./ sum(ws) + reg * I
+    Ct = (xt .* wt)' * xt ./ sum(wt) + reg * I
+
+    eigs = eigen(Symmetric(Cs))
+    vals = reverse(eigs.values)
+    vecs = eigs.vectors[:, end:-1:1]
+
+    a_s = vals[1:ds]
+    sigma_2s = (tr(Cs) - sum(a_s)) / (p - ds)
+    Us = vecs[:, 1:ds]
+    ls = a_s .- sigma_2s
+
+    eigt = eigen(Symmetric(Ct))
+    valt = reverse(eigt.values)
+    vect = eigt.vectors[:, end:-1:1]
+
+    a_t = valt[1:dt]
+    sigma_2t = (tr(Ct) - sum(a_t)) / (p - dt)
+    Ut = vect[:, 1:dt]
+    lt = a_t .- sigma_2t
+
+    return bures_wasserstein_distance_hd(mxs, mxt, Us, Ut, ls, lt, sigma_2s, sigma_2t)
+end
+        
+    
+            
+    

--- a/test/gaussian_hd.jl
+++ b/test/gaussian_hd.jl
@@ -1,0 +1,239 @@
+using Test
+using LinearAlgebra
+using Random
+using Statistics
+
+# Import only the four new functions added to OptimalTransport.jl.
+using OptimalTransport:
+    bures_wasserstein_distance_hd,
+    empirical_bures_wasserstein_distance_hd,
+    bures_wasserstein_mapping_hd,
+    empirical_bures_wasserstein_mapping_hd
+
+# Build a p x d matrix with orthonormal columns.
+# The HD Gaussian formulas assume that U spans an orthonormal principal subspace.
+function orthonormal_columns(p, d)
+    return Matrix(qr(randn(p, d)).Q)
+end
+
+# Reconstruct the full dense covariance matrix from the HD Gaussian model:
+#
+#     Sigma = U * Diagonal(l) * U' + sigma2 * I
+#
+# This is used only in tests to compare the HD implementation with a dense
+# reference formula in small dimension.
+function covariance_hd(U, l, sigma2)
+    p = size(U, 1)
+    return U * Diagonal(l) * U' + sigma2 * Matrix{Float64}(I, p, p)
+end
+
+# Dense reference formula for the Bures-Wasserstein distance between two
+# Gaussian distributions N(ms, Cs) and N(mt, Ct).
+#
+# This is not the scalable HD formula. It explicitly uses dense covariance
+# matrices, so it is suitable as a correctness check for small dimensions.
+function dense_bures_wasserstein_distance(ms, mt, Cs, Ct)
+    Cs_sqrt = sqrt(Symmetric(Cs))
+    middle = Cs_sqrt * Ct * Cs_sqrt
+
+    W2 = (
+        sum(abs2, ms .- mt)
+        + tr(Cs)
+        + tr(Ct)
+        - 2 * tr(sqrt(Symmetric(middle)))
+    )
+
+    # The max protects against tiny negative values caused by roundoff,
+    # for example W2 = -1e-14 instead of exactly zero.
+    return sqrt(max(real(W2), 0.0))
+end
+
+# Dense reference formula for the optimal affine transport map:
+#
+#     T(x) = A * x + b
+#
+# between two Gaussian distributions N(ms, Cs) and N(mt, Ct).
+#
+# We use it to check that the HD implementation returns the same A and b
+# as the classical dense formula.
+function dense_bures_wasserstein_mapping(ms, mt, Cs, Ct)
+    Cs_sqrt = sqrt(Symmetric(Cs))
+    Cs_invsqrt = inv(Cs_sqrt)
+
+    middle = sqrt(Symmetric(Cs_sqrt * Ct * Cs_sqrt))
+
+    A = Cs_invsqrt * middle * Cs_invsqrt
+    b = mt - A * ms
+
+    return A, b
+end
+
+@testset "HD Gaussian Bures-Wasserstein distance" begin
+    Random.seed!(1234)
+
+    # Use a small ambient dimension so that the dense reference computation
+    # is cheap and numerically stable.
+    p = 20
+    ds = 4
+    dt = 5
+
+    # The means are different, so the test also checks the ||ms - mt|| term.
+    ms = zeros(p)
+    mt = vcat(3.0, zeros(p - 1))
+
+    # Principal subspaces for the source and target HD Gaussian models.
+    Us = orthonormal_columns(p, ds)
+    Ut = orthonormal_columns(p, dt)
+
+    # Principal variances in each low-dimensional subspace.
+    ls = [6.0, 4.0, 2.0, 1.0]
+    lt = [5.0, 3.0, 2.0, 1.0, 0.5]
+
+    # Residual isotropic variances.
+    sigma_s2 = 0.7
+    sigma_t2 = 0.4
+
+    # Reconstruct full covariance matrices to compute a dense reference result.
+    Cs = covariance_hd(Us, ls, sigma_s2)
+    Ct = covariance_hd(Ut, lt, sigma_t2)
+
+    # Distance computed by the new HD implementation.
+    W_hd = bures_wasserstein_distance_hd(ms, mt, Us, Ut, ls, lt, sigma_s2, sigma_t2)
+
+    # Distance computed by the classical dense formula.
+    W_dense = dense_bures_wasserstein_distance(ms, mt, Cs, Ct)
+
+    # Main correctness check: the HD formula should match the dense formula.
+    @test W_hd ≈ W_dense rtol = 1e-8 atol = 1e-8
+
+    # Basic numerical sanity checks.
+    @test isfinite(W_hd)
+    @test W_hd >= 0
+
+    # Identity case: the distance between a Gaussian and itself should be zero.
+    W_same = bures_wasserstein_distance_hd(ms, ms, Us, Us, ls, ls, sigma_s2, sigma_s2)
+
+    @test W_same ≈ 0 atol = 1e-8
+end
+
+@testset "HD Gaussian Bures-Wasserstein mapping" begin
+    Random.seed!(5678)
+
+    p = 20
+    ds = 4
+    dt = 5
+
+    ms = zeros(p)
+    mt = vcat(2.0, -1.0, zeros(p - 2))
+
+    Us = orthonormal_columns(p, ds)
+    Ut = orthonormal_columns(p, dt)
+
+    ls = [6.0, 4.0, 2.0, 1.0]
+    lt = [5.0, 3.0, 2.0, 1.0, 0.5]
+
+    sigma_s2 = 0.7
+    sigma_t2 = 0.4
+
+    Cs = covariance_hd(Us, ls, sigma_s2)
+    Ct = covariance_hd(Ut, lt, sigma_t2)
+
+    # Transport map computed by the new HD implementation.
+    A_hd, b_hd = bures_wasserstein_mapping_hd(ms, mt, Us, Ut, ls, lt, sigma_s2, sigma_t2)
+
+    # Transport map computed by the dense reference formula.
+    A_dense, b_dense = dense_bures_wasserstein_mapping(ms, mt, Cs, Ct)
+
+    # Main correctness checks: A and b should match the dense reference.
+    @test A_hd ≈ A_dense rtol = 1e-8 atol = 1e-8
+    @test b_hd ≈ b_dense rtol = 1e-8 atol = 1e-8
+
+    # Basic numerical sanity checks.
+    @test all(isfinite, A_hd)
+    @test all(isfinite, b_hd)
+
+    # Simple case: same covariance, different means.
+    # The optimal map should be a pure translation:
+    #
+    #     T(x) = x + (mt - ms)
+    #
+    # Therefore A should be I and b should be mt - ms.
+    A_same, b_same = bures_wasserstein_mapping_hd(ms, mt, Us, Us, ls, ls, sigma_s2, sigma_s2)
+
+    @test A_same ≈ Matrix{Float64}(I, p, p) atol = 1e-7
+    @test b_same ≈ mt - ms atol = 1e-7
+end
+
+@testset "Empirical HD Gaussian Bures-Wasserstein distance" begin
+    Random.seed!(42)
+
+    n = 300
+    p = 15
+    d = 3
+
+    # Generate a source sample cloud.
+    xs = randn(n, p)
+
+    # The target sample cloud is exactly the source cloud translated by shift.
+    # Therefore the empirical covariances are identical and only the means differ.
+    shift = collect(range(0.1, 1.5; length=p))
+    xt = xs .+ shift'
+
+    # Since only the mean changes, the expected Wasserstein distance is norm(shift).
+    W = empirical_bures_wasserstein_distance_hd(xs, xt; d_intrinsic=d, reg=1e-8, bias=true)
+
+    @test W ≈ norm(shift) atol = 1e-6
+    @test isfinite(W)
+    @test W >= 0
+
+    # Identity case: same source and target samples should give zero distance.
+    W_same = empirical_bures_wasserstein_distance_hd(xs, xs; d_intrinsic=d, reg=1e-8, bias=true)
+
+    @test W_same <= 1e-7
+end
+
+@testset "Empirical HD Gaussian Bures-Wasserstein mapping" begin
+    Random.seed!(43)
+
+    n = 300
+    p = 15
+    d = 3
+
+    xs = randn(n, p)
+
+    # The target is a translated copy of the source.
+    # The expected optimal map is therefore A = I and b = shift.
+    shift = collect(range(-0.5, 1.0; length=p))
+    xt = xs .+ shift'
+
+    A, b = empirical_bures_wasserstein_mapping_hd(xs, xt, d; reg=1e-8, bias=true)
+
+    # Check output dimensions.
+    @test size(A) == (p, p)
+    @test size(b) == (p,)
+
+    # Check that the output does not contain NaN or Inf values.
+    @test all(isfinite, A)
+    @test all(isfinite, b)
+
+    # Because source and target have the same empirical covariance, up to
+    # translation, the optimal map should be A = I and b = shift.
+    @test A ≈ Matrix{Float64}(I, p, p) atol = 1e-6
+    @test b ≈ shift atol = 1e-6
+
+    # Samples are stored by rows: xs has shape n x p.
+    # The mathematical formula is T(x) = A * x + b for column vectors.
+    # For row-wise samples, the equivalent operation is xs * A' .+ b'.
+    Xst = xs * A' .+ b'
+
+    # After applying the transport map, the transported sample mean should
+    # match the target sample mean.
+    @test vec(mean(Xst; dims=1)) ≈ vec(mean(xt; dims=1)) atol = 1e-6
+
+    # Empirical identity case: source and target are exactly the same sample cloud.
+    # The expected map is A = I and b = 0.
+    A_same, b_same = empirical_bures_wasserstein_mapping_hd(xs, xs, d; reg=1e-8, bias=true)
+
+    @test A_same ≈ Matrix{Float64}(I, p, p) atol = 1e-6
+    @test b_same ≈ zeros(p) atol = 1e-6
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,6 +12,10 @@ const GROUP = get(ENV, "GROUP", "All")
             include("utils.jl")
         end
 
+	@safetestset "Gaussian" begin
+    	    include("gaussian_hd.jl")
+	end	
+
         @testset "Entropically regularized OT" begin
             @safetestset "Sinkhorn Gibbs" begin
                 include(joinpath("entropic", "sinkhorn_gibbs.jl"))
@@ -49,4 +53,3 @@ const GROUP = get(ENV, "GROUP", "All")
             include(joinpath("gpu/simple_gpu.jl"))
         end
     end
-end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,10 +10,12 @@ const GROUP = get(ENV, "GROUP", "All")
     if GROUP == "All" || GROUP == "OptimalTransport"
         @safetestset "Utilities" begin
             include("utils.jl")
-	end
+        end
+
         @safetestset "Gaussian" begin
             include("gaussian_hd.jl")
-	end	
+        end
+
         @testset "Entropically regularized OT" begin
             @safetestset "Sinkhorn Gibbs" begin
                 include(joinpath("entropic", "sinkhorn_gibbs.jl"))
@@ -51,3 +53,4 @@ const GROUP = get(ENV, "GROUP", "All")
             include(joinpath("gpu/simple_gpu.jl"))
         end
     end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,12 +10,10 @@ const GROUP = get(ENV, "GROUP", "All")
     if GROUP == "All" || GROUP == "OptimalTransport"
         @safetestset "Utilities" begin
             include("utils.jl")
-        end
-
-	@safetestset "Gaussian" begin
-    	    include("gaussian_hd.jl")
+	end
+        @safetestset "Gaussian" begin
+            include("gaussian_hd.jl")
 	end	
-
         @testset "Entropically regularized OT" begin
             @safetestset "Sinkhorn Gibbs" begin
                 include(joinpath("entropic", "sinkhorn_gibbs.jl"))


### PR DESCRIPTION
This PR is part of a research project where one objective is to add high-dimensional Gaussian optimal transport utilities from the paper [Scaling Optimal Transport to High-Dimensional Gaussian Distributions](https://hal.science/hal-04930868/document).

It adds four Bures-Wasserstein utilities:
- bures_wasserstein_distance_hd: computes the 2-Wasserstein distance between two HD Gaussian distributions.
- empirical_bures_wasserstein_distance_hd: estimates this distance from empirical samples using PPCA-style covariance estimates.
- bures_wasserstein_mapping_hd: computes the optimal affine transport map between two HD Gaussian distributions.
- empirical_bures_wasserstein_mapping_hd: estimates this affine transport map from empirical samples.

It also adds tests for the exact and empirical distance/mapping functions, including comparisons with dense Gaussian reference formulas and simple identity/translation cases.